### PR TITLE
Adding MIT License #17

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Pranav016 and ALPHAVIO
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Adding MIT License on the name of Copyright (c) 2021 Pranav016 and ALPHAVIO
as per the issue #17

## What is the change?
Added LICENCE as in #17

## Related issue?
closes: #17

## How was it tested?
added as per  https://github.com/ALPHAVIO/WordNook/blob/master/LICENSE

## Checklist:
Before you create this PR, confirm all the requirements listed below by checking the checkboxes `[x]`:

-   [x] Have you followed the [Contribution Guidelines](https://github.com/ALPHAVIO/BlogSite/blob/master/CONTRIBUTING.md) while contributing.
-   [x] Have you checked there aren't other open [Pull Requests](https://github.com/ALPHAVIO/Mirage-UI/pulls) for the same update/change?
-   [x] Have you made corresponding changes to the documentation?
-   [x] Have you tested the code before submission?
-   [x] Did you lint and format your code before making the Pull Request?
-   [x] Have you made the GIF for the component you added?

## GIF you created:
Not needed
